### PR TITLE
Add compressed archive download and extract

### DIFF
--- a/helloworld-eap6.4-binary/.s2i/bin/run
+++ b/helloworld-eap6.4-binary/.s2i/bin/run
@@ -5,5 +5,10 @@ if [ -n "${SOLR_CONF_URL}" ]; then
   curl -v ${SOLR_CONF_URL} -o ${JBOSS_HOME}/conf/solrcore.properties
 fi
 
+if [ -n "${COMPRESSED_ARCHIVE_URL}" ] && [ -n "${COMPRESSED_ARCHIVE_HOME}" ]; then
+  curl -v ${COMPRESSED_ARCHIVE_URL} -o ${COMPRESSED_ARCHIVE_DESTINATION}
+  tar -xvf ${COMPRESSED_ARCHIVE_DESTINATION} --directory ${COMPRESSED_ARCHIVE_HOME}
+fi
+
 exec $JBOSS_HOME/bin/openshift-launch.sh
 


### PR DESCRIPTION
Gives the ability to download an arbitrary archive and untar  it to a specific location.

New env variables 
COMPRESSED_ARCHIVE_URL = where should the script download the archive
COMPRESSED_ARCHIVE_DESTINATION = where should this archive sit on the image
COMPRESSED_ARCHIVE_HOME = a directory where the archive will be extracted

This does not delete the artifact from disk. 